### PR TITLE
MyMod: Append newline `\n` to the exported JSON config

### DIFF
--- a/rpfm_lib/src/packfile/mod.rs
+++ b/rpfm_lib/src/packfile/mod.rs
@@ -1625,6 +1625,7 @@ impl PackFile {
                     data.write_all(to_string_pretty(&self.settings)?.as_bytes())?;
                     let path = extracted_path.join(RESERVED_NAME_SETTINGS.to_owned() + ".json");
                     let mut file = BufWriter::new(File::create(path)?);
+                    data.extend_from_slice(b"\n"); // Add newline to the end of the file
                     file.write_all(&data)?;
                     file.flush()?;
                 }


### PR DESCRIPTION
Adds a newline character `\n` to the exported MyMod JSON config file `settings.rpfm_reserved.json` to [properly terminate it](https://stackoverflow.com/questions/729692/why-should-text-files-end-with-a-newline/729795#729795).

This little PR was inspired by Frodo in [this Discord message](https://discord.com/channels/373745291289034763/498934055564476416/891658304152035379).