### PR TITLE
Update test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,20 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          
+
+      - name: Cache build target
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
       - name: Build rpfm-lib
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
This fixes `The package requires the Cargo feature called "edition2021", but that feature is not stabilized in this version of Cargo (1.55.0 (32da73ab1 2021-08-23)).` error that occurs during Linux debug build workflows for `rpfm_lib` and `rpfm_cli`:
https://github.com/im-mortal/rpfm/runs/3992112291?check_suite_focus=true

Also kinda sorta ensures future updates to Rust toolchain will be available to the workflow immediately.

Additionally, the updated workflow leverages GitHub Cache action, which drastically reduces build times for subsequent builds. Compare: [run #1](https://github.com/im-mortal/rpfm/runs/3993502015?check_suite_focus=true) (4m 25s) vs [run #2](https://github.com/im-mortal/rpfm/runs/3993532239?check_suite_focus=true) (1m 13s).