### PR TITLE
Move Lua LSP config to `.luarc.json` for new MyMods

### DIFF
--- a/rpfm_ui/src/background_thread.rs
+++ b/rpfm_ui/src/background_thread.rs
@@ -1677,8 +1677,8 @@ pub fn background_loop() {
                                 let mut vscode_extensions_path_file = vscode_config_path.to_owned();
                                 vscode_extensions_path_file.push("extensions.json");
 
-                                let mut vscode_config_path_file = vscode_config_path.to_owned();
-                                vscode_config_path_file.push("settings.json");
+                                let mut luarc_config_path = mymod_path.to_owned();
+                                luarc_config_path.push(".luarc.json");
 
                                 if let Ok(file) = File::create(vscode_extensions_path_file) {
                                     let mut file = BufWriter::new(file);
@@ -1691,28 +1691,28 @@ pub fn background_loop() {
 }".as_bytes());
                                 }
 
-                                if let Ok(file) = File::create(vscode_config_path_file) {
+                                if let Ok(file) = File::create(luarc_config_path) {
                                     let mut file = BufWriter::new(file);
                                     let _ = file.write_all(format!("
 {{
-    \"Lua.workspace.library\": [
+    \"workspace.library\": [
         \"{folder}/global/\",
         \"{folder}/campaign/\",
         \"{folder}/frontend/\",
         \"{folder}/battle/\"
     ],
-    \"Lua.runtime.version\": \"Lua 5.1\",
-    \"Lua.completion.autoRequire\": false,
-    \"Lua.workspace.preloadFileSize\": 1500,
-    \"Lua.workspace.ignoreSubmodules\": false,
-    \"Lua.diagnostics.workspaceDelay\": 500,
-    \"Lua.diagnostics.workspaceRate\": 40,
-    \"Lua.diagnostics.disable\": [
+    \"runtime.version\": \"Lua 5.1\",
+    \"completion.autoRequire\": false,
+    \"workspace.preloadFileSize\": 1500,
+    \"workspace.ignoreSubmodules\": false,
+    \"diagnostics.workspaceDelay\": 500,
+    \"diagnostics.workspaceRate\": 40,
+    \"diagnostics.disable\": [
         \"lowercase-global\",
         \"trailing-space\"
     ],
-    \"Lua.hint.setType\": true,
-    \"Lua.workspace.ignoreDir\": [
+    \"hint.setType\": true,
+    \"workspace.ignoreDir\": [
         \".vscode\",
         \".git\"
     ]
@@ -1728,37 +1728,8 @@ pub fn background_loop() {
         {{
             \"path\": \".\"
         }}
-    ],
-    \"settings\": {{
-        \"LSP\": {{
-            \"LSP-lua\": {{
-                \"settings\": {{
-                    \"Lua.workspace.library\": [
-                        \"{folder}/global/\",
-                        \"{folder}/campaign/\",
-                        \"{folder}/frontend/\",
-                        \"{folder}/battle/\"
-                    ],
-                    \"Lua.runtime.version\": \"Lua 5.1\",
-                    \"Lua.completion.autoRequire\": false,
-                    \"Lua.workspace.preloadFileSize\": 1500,
-                    \"Lua.workspace.ignoreSubmodules\": false,
-                    \"Lua.diagnostics.workspaceDelay\": 500,
-                    \"Lua.diagnostics.workspaceRate\": 40,
-                    \"Lua.diagnostics.disable\": [
-                        \"lowercase-global\",
-                        \"trailing-space\"
-                    ],
-                    \"Lua.hint.setType\": true,
-                    \"Lua.workspace.ignoreDir\": [
-                        \".vscode\",
-                        \".git\"
-                    ],
-                }}
-            }}
-        }}
-    }}
-}}", folder = lua_autogen_folder).as_bytes());
+    ]
+}}").as_bytes());
                                 }
                             }
                         }


### PR DESCRIPTION
This PR moves the generated Lua LSP config when a new mod is made through RPFM out of editor specific files into the `.luarc.json`. as a result any editor using Sumneko's LSP Server now support code completion from tw_autogen out of the box. 

The change I suggested in #216  was simple to implement, so I went ahead  and implemented it.
Porting the change directly to v4, should be possible. 

I've included a more detailed description on the change in the commit message, a copy for easy reference.
```
New MyMods created for games supporting tw_autogen, now have the lua LSP
config written to `.luarc.json` instead of `.vscode/settings.json`
and `.sublime-project`.

As VSCode and Sublime Text both uses Sumneko's Lua LSP server, which
supports per project configuration via `.luarc.json` file. This allows
other editors using the LSP server by Sumneko to come pre-configured with
tw_autogen out of the box, same way as Sublime Text and VSCode.

Previously the Lua LSP config was written to `.vscode/settings.json` and
`.sublime-project` for VSCode and Sublime Text respectively. Any other
editor required the config to manually be migrated to `.luarc.json`.
```

Closes: #216 