### PR TITLE
Fix extracting folders / files from CLI

### DIFF
--- a/rpfm_cli/src/app/mod.rs
+++ b/rpfm_cli/src/app/mod.rs
@@ -59,7 +59,7 @@ pub fn initialize_app<'a>() -> Command<'a> {
             .takes_value(true))
 
         // `AssKit DB Path` flag. This is required for certain operations requiring the dependencies cache.
-        .arg(Arg::new("asskit_db_path")
+        .arg(Arg::new("assdb")
             .short('a')
             .long("assdb")
             .value_name("ASSKIT DB PATH")

--- a/rpfm_cli/src/commands/mod.rs
+++ b/rpfm_cli/src/commands/mod.rs
@@ -78,7 +78,7 @@ pub fn command_packfile(config: &Config, matches: &ArgMatches, packfile: Option<
                 match matches.values_of("extract-files") {
                     Some(mut values) => {
                         let destination_path = values.next().unwrap();
-                        let packed_file_paths = values.enumerate().filter(|(x, _)| x != &0).map(|(_, y)| y).collect::<Vec<&str>>();
+                        let packed_file_paths = values.enumerate().map(|(_, y)| y).collect::<Vec<&str>>();
                         packfile::extract_files(config, packfile_path, &packed_file_paths, destination_path)
                     },
                     None => Err(ErrorKind::NoHTMLError("No valid argument provided.".to_owned()).into())
@@ -89,7 +89,7 @@ pub fn command_packfile(config: &Config, matches: &ArgMatches, packfile: Option<
                 match matches.values_of("extract-folders") {
                     Some(mut values) => {
                         let destination_path = values.next().unwrap();
-                        let folder_paths = values.enumerate().filter(|(x, _)| x != &0).map(|(_, y)| y).collect::<Vec<&str>>();
+                        let folder_paths = values.enumerate().map(|(_, y)| y).collect::<Vec<&str>>();
                         packfile::extract_folders(config, packfile_path, &folder_paths, destination_path)
                     },
                     None => Err(ErrorKind::NoHTMLError("No valid argument provided.".to_owned()).into())


### PR DESCRIPTION
I was playing around with the CLI and noticed that exporting files / folders didn't work as expected. Here's a short summary of my investigation - it seems that Rust's iterator .enumerate() starts from the pointer, not the whole Iterator?


```
let destination_path = values.next().unwrap(); 
// .next() called, so values now points to the first packed_file_path 
let packed_file_paths = values.enumerate().filter(|(x, _)| x != &0).map(|(_, y)| y).collect::<Vec<&str>>(); 
// the .filter call will filter out the item at index 0, which will be the first packed file path
```

Just got a random mod and did some testing:

Folders:
```
cargo run -- -g warhammer_3 -p <path-to-packfile> -vvv packfile -E <destination> db
cargo run -- -g warhammer_3 -p <path-to-packfile> -vvv packfile -E <destination> db scripts
```
Files:
```
cargo run -- -g warhammer_3 -p <path-to-packfile> -vvv packfile -e <destination> db/_kv_rules_tables/!ccextreme db/_kv_unit_ability_scaling_rules_tables/!ccextreme
```

There's also a small fix as the CLI library can't seem to find "asskit_db_path" as it references "assdb" (main.rs, L49).

Also from my end, I'm not 100% sure if the CLI is used in the main app at all and if that breaks anything there - if so, please feel free to disregard this PR!