### PR TITLE
Give flatpak network access

### DIFF
--- a/install/linux/flatpak/com.github.frodo45127.rpfm.yaml
+++ b/install/linux/flatpak/com.github.frodo45127.rpfm.yaml
@@ -15,6 +15,7 @@ finish-args:
   - --socket=pulseaudio
 
   # Access to the outside world
+  - --share=network
   - --filesystem=host
 
   # Additional permissions


### PR DESCRIPTION
Update to give flatpak network share permission to retrieve updates from https git and make mcp urls available outside flatpak.

This allows external connections to `http://127.0.0.1:45127/mcp` as well as allowing rpfm to reach external git remotes for update behavior.