### PR TITLE
Upgrade MCP server to rmcp 3.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,6 +506,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4119,12 +4125,12 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.7.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+checksum = "ad26b216c966e987e80e86daf784a455c039c43d98575ceed57b8faa259e5695"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.0",
  "bytes",
  "chrono",
  "futures",
@@ -4150,9 +4156,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.7.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+checksum = "41bc748630c2be2a71b614c2f40d27bc0df0060696d224e1692c72345b7e0b79"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -5085,9 +5091,9 @@ dependencies = [
 
 [[package]]
 name = "sse-stream"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
 dependencies = [
  "bytes",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,5 +99,5 @@ zip = { version = "^8", default-features = false, features = ["deflate"] }
 fs_extra = "^1.3"
 caseless = "^0.2"
 half = "^2"
-rmcp = { version = "^1.5", features = ["server", "transport-io", "transport-streamable-http-server", "macros"] }
+rmcp = { version = "^3", default-features = false, features = ["server", "transport-io", "transport-streamable-http-server", "macros"] }
 schemars = "1.0"

--- a/rpfm_server/src/server_mcp.rs
+++ b/rpfm_server/src/server_mcp.rs
@@ -38,16 +38,15 @@
 use rmcp::ErrorData as McpError;
 use rmcp::handler::server::{router::prompt::PromptRouter, tool::ToolRouter, wrapper::Parameters};
 use rmcp::model::{
-    Annotated, CallToolResult, CompletionInfo, CompleteRequestParams, CompleteResult,
-    Content, ErrorCode, GetPromptRequestParams, GetPromptResult,
-    ListPromptsResult, ListResourcesResult, ListResourceTemplatesResult,
-    PaginatedRequestParams, PromptMessage, PromptMessageRole,
-    RawResource, ReadResourceRequestParams, ReadResourceResult,
-    ResourceContents, ServerCapabilities, ServerInfo, SetLevelRequestParams,
+    CallToolResult, CompletionInfo, CompleteRequestParams, CompleteResult,
+    ContentBlock, ErrorCode, ListResourcesResult, ListResourceTemplatesResult,
+    PaginatedRequestParams, PromptMessage,
+    ReadResourceRequestParams, ReadResourceResult, ReadResourceResponse,
+    Resource, ResourceContents, Role, ServerCapabilities, ServerInfo,
 };
-use rmcp::schemars::JsonSchema;
 use rmcp::service::RequestContext;
 use rmcp::{prompt, prompt_handler, prompt_router, tool, tool_handler, tool_router, RoleServer};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -98,19 +97,18 @@ macro_rules! send_and_respond {
         })?;
 
         if is_error {
-            Ok(CallToolResult::error(vec![Content::text(json)]))
+            Ok(CallToolResult::error(vec![ContentBlock::text(json)]))
         } else {
-            Ok(CallToolResult::success(vec![Content::text(json)]))
+            Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
         }
     }};
 }
 
-/// Build an Annotated<RawResource> with common fields set.
-fn resource(uri: &str, name: &str, description: &str, mime_type: &str) -> Annotated<RawResource> {
-    let mut raw = RawResource::new(uri, name);
-    raw.description = Some(description.into());
-    raw.mime_type = Some(mime_type.into());
-    Annotated { raw, annotations: None }
+/// Build a `Resource` with common fields set.
+fn resource(uri: &str, name: &str, description: &str, mime_type: &str) -> Resource {
+    Resource::new(uri, name)
+        .with_description(description)
+        .with_mime_type(mime_type)
 }
 
 /// Parse a JSON string into the expected type, returning a tool-level error on failure.
@@ -122,7 +120,7 @@ macro_rules! parse_json {
     ($input:expr) => {
         match serde_json::from_str($input) {
             Ok(v) => v,
-            Err(e) => return Ok(CallToolResult::error(vec![Content::text(format!("Invalid JSON parameter: {e}"))])),
+            Err(e) => return Ok(CallToolResult::error(vec![ContentBlock::text(format!("Invalid JSON parameter: {e}"))])),
         }
     };
 }
@@ -813,7 +811,6 @@ impl rmcp::ServerHandler for McpServer {
             .enable_prompts()
             .enable_resources()
             .enable_completions()
-            .enable_logging()
             .build();
 
         // `ServerInfo` is `#[non_exhaustive]` in rmcp, so it must be built through its constructor instead of a struct literal.
@@ -925,7 +922,7 @@ All tool responses are JSON-serialized. On failure, an error message is returned
         &self,
         request: ReadResourceRequestParams,
         _context: RequestContext<RoleServer>,
-    ) -> Result<ReadResourceResult, McpError> {
+    ) -> Result<ReadResourceResponse, McpError> {
         let uri = &request.uri;
         let content = match uri.as_str() {
             "rpfm://games" => serde_json::json!({
@@ -1203,7 +1200,7 @@ Maps:
             }
         };
 
-        Ok(ReadResourceResult::new(vec![ResourceContents::text(content, uri.clone())]))
+        Ok(ReadResourceResult::new(vec![ResourceContents::text(content, uri.clone())]).into())
     }
 
     //-----------------------------------------------------------------------//
@@ -1266,27 +1263,17 @@ Maps:
         let values: Vec<String> = candidates.into_iter().take(100).collect();
         let has_more = total > 100;
 
-        Ok(CompleteResult::new(CompletionInfo {
+        Ok(CompleteResult::new(CompletionInfo::with_pagination(
             values,
-            total: Some(total),
-            has_more: Some(has_more),
-        }))
+            Some(total),
+            has_more,
+        ).map_err(|e| McpError {
+            code: ErrorCode::INTERNAL_ERROR,
+            message: format!("Failed to build completion info: {e}").into(),
+            data: None,
+        })?))
     }
 
-    //-----------------------------------------------------------------------//
-    // Logging
-    //-----------------------------------------------------------------------//
-
-    async fn set_level(
-        &self,
-        _request: SetLevelRequestParams,
-        _context: RequestContext<RoleServer>,
-    ) -> Result<(), McpError> {
-        // Acknowledge the logging level request. RPFM uses its own logging
-        // infrastructure (rpfm_telemetry/sentry), so we accept the request but
-        // don't change the internal log level.
-        Ok(())
-    }
 }
 
 #[tool_router]
@@ -2186,7 +2173,7 @@ impl McpServer {
     #[prompt(name = "open_and_inspect_pack", description = "Walk through opening a PackFile and inspecting its contents.")]
     pub async fn open_and_inspect_pack(&self) -> Vec<PromptMessage> {
         vec![PromptMessage::new_text(
-            PromptMessageRole::User,
+            Role::User,
             "\
 You are an assistant helping the user inspect a Total War PackFile using the RPFM MCP server.
 
@@ -2219,7 +2206,7 @@ Important notes:
     #[prompt(name = "edit_db_table", description = "Guide for reading, modifying, and saving a DB table inside a pack.")]
     pub async fn edit_db_table(&self) -> Vec<PromptMessage> {
         vec![PromptMessage::new_text(
-            PromptMessageRole::User,
+            Role::User,
             "\
 You are an assistant helping the user edit a DB table inside a Total War PackFile.
 
@@ -2252,7 +2239,7 @@ Tips:
     #[prompt(name = "create_new_mod", description = "Step-by-step guide for creating a new mod PackFile from scratch.")]
     pub async fn create_new_mod(&self) -> Vec<PromptMessage> {
         vec![PromptMessage::new_text(
-            PromptMessageRole::User,
+            Role::User,
             "\
 You are an assistant helping the user create a new Total War mod from scratch.
 
@@ -2289,7 +2276,7 @@ Optional steps:
     #[prompt(name = "search_and_replace", description = "Find and replace values across all files in a pack.")]
     pub async fn search_and_replace(&self) -> Vec<PromptMessage> {
         vec![PromptMessage::new_text(
-            PromptMessageRole::User,
+            Role::User,
             "\
 You are an assistant helping the user search for and replace data across a PackFile.
 
@@ -2323,7 +2310,7 @@ Related tools:
     #[prompt(name = "manage_dependencies", description = "Set up and work with game dependencies and vanilla data.")]
     pub async fn manage_dependencies(&self) -> Vec<PromptMessage> {
         vec![PromptMessage::new_text(
-            PromptMessageRole::User,
+            Role::User,
             "\
 You are an assistant helping the user work with dependency data (vanilla game files).
 
@@ -2369,7 +2356,7 @@ Tips:
     #[prompt(name = "run_diagnostics", description = "Validate a pack and fix common issues.")]
     pub async fn run_diagnostics(&self) -> Vec<PromptMessage> {
         vec![PromptMessage::new_text(
-            PromptMessageRole::User,
+            Role::User,
             "\
 You are an assistant helping the user validate a Total War mod PackFile.
 
@@ -2411,7 +2398,7 @@ Workflow:
     #[prompt(name = "schema_operations", description = "Work with table schemas: inspect, update, and patch definitions.")]
     pub async fn schema_operations(&self) -> Vec<PromptMessage> {
         vec![PromptMessage::new_text(
-            PromptMessageRole::User,
+            Role::User,
             "\
 You are an assistant helping the user manage RPFM table schemas.
 
@@ -2457,7 +2444,7 @@ Workflow:
     #[prompt(name = "file_operations", description = "Add, remove, rename, extract, and move files within packs.")]
     pub async fn file_operations(&self) -> Vec<PromptMessage> {
         vec![PromptMessage::new_text(
-            PromptMessageRole::User,
+            Role::User,
             "\
 You are an assistant helping the user manage files inside a Total War PackFile.
 
@@ -2514,7 +2501,7 @@ Always call `save_packfile` or `save_pack_as` when done to persist changes.
     #[prompt(name = "troubleshooting", description = "Diagnose and fix common issues with RPFM and PackFiles.")]
     pub async fn troubleshooting(&self) -> Vec<PromptMessage> {
         vec![PromptMessage::new_text(
-            PromptMessageRole::User,
+            Role::User,
             "\
 You are an assistant helping the user troubleshoot common RPFM and PackFile issues.
 
@@ -2574,7 +2561,7 @@ You are an assistant helping the user troubleshoot common RPFM and PackFile issu
     #[prompt(name = "tsv_workflow", description = "Import and export tables as TSV files for batch editing in spreadsheets.")]
     pub async fn tsv_workflow(&self) -> Vec<PromptMessage> {
         vec![PromptMessage::new_text(
-            PromptMessageRole::User,
+            Role::User,
             "\
 You are an assistant helping the user work with TSV (Tab-Separated Values) files for batch editing \
 Total War mod data in spreadsheets.
@@ -2624,7 +2611,7 @@ Total War mod data in spreadsheets.
     #[prompt(name = "translation_workflow", description = "Work with localisation and translation data in PackFiles.")]
     pub async fn translation_workflow(&self) -> Vec<PromptMessage> {
         vec![PromptMessage::new_text(
-            PromptMessageRole::User,
+            Role::User,
             "\
 You are an assistant helping the user work with localisation (translation) data in Total War mods.
 


### PR DESCRIPTION
﻿## Summary

Upgrades the MCP server (`rpfm_server`) from **rmcp 1.7** to **rmcp 3.1** and migrates `rpfm_server/src/server_mcp.rs` to the renamed rmcp 3.x model types.

## Why

The old rmcp 1.7 pinned the server to the 2024-11-05 MCP protocol spec. rmcp 3.x tracks the current spec, so this upgrade brings the RPFM MCP server up to supporting the **latest MCP protocol (2026-07-28)** — alongside the older 2025-06-18, 2025-11-25 and 2024-11-05 versions — via the SDK's `supported_protocol_versions()`. That keeps the server interoperable with modern MCP clients that negotiate the newest spec, while still serving legacy clients.

rmcp 3.x renamed a number of public types and made some structs `#[non_exhaustive]`. This PR adapts the handler to the new API:

- **`Content` → `ContentBlock`** — tool-result payloads in `send_and_respond!` and the `parse_json!` macro.
- **`PromptMessageRole` → `Role`** — all prompt definitions (`Role::User`).
- **`Annotated<RawResource>` → `Resource`** — the `resource()` helper now builds a `Resource` via its `with_description` / `with_mime_type` builders.
- **`read_resource` returns `ReadResourceResponse`** — the new MRTR wrapper around `ReadResourceResult` (returned via `.into()`).
- **`CompletionInfo` is now `#[non_exhaustive]`** — built through `CompletionInfo::with_pagination(...)` instead of a struct literal.
- **Removed the deprecated `set_level` handler and `enable_logging()`** — logging is deprecated by SEP-2577.

Also updates the dependency declaration in `Cargo.toml` (`rmcp = { version = "^3", default-features = false, ... }`) and the corresponding `Cargo.lock` entries.

## Verification

- `cargo check -p rpfm_server` — clean, no errors or warnings.
- `cargo build -p rpfm_server` — compiles and links the binary against rmcp 3.1.0.
- Drove the dev server over MCP (Streamable-HTTP): `initialize` handshake, `tools/list` (150 tools advertised with schemars JSON schemas), and live tool calls (`get_game_selected`, `list_open_packs`) all return correct results.

## Notes

- No rustfmt applied (per CONTRIBUTING.md).
- Only `rpfm_server` uses `rmcp`, so the change is contained to that crate.
