### PR TITLE
Clippy fixes.

### DIFF
--- a/rpfm_extensions/src/dependencies/mod.rs
+++ b/rpfm_extensions/src/dependencies/mod.rs
@@ -1012,7 +1012,7 @@ impl Dependencies {
 
             // First check in /data. If we have packs there, do not bother checking for external Packs.
             if let Some(path) = data_paths.iter().find(|x| x.file_name().unwrap().to_string_lossy() == pack_name) {
-                if let Ok(pack) = Pack::read_and_merge(&[path.to_path_buf()], game_info, true, false, false) {
+                if let Ok(pack) = Pack::read_and_merge(std::slice::from_ref(path), game_info, true, false, false) {
                     already_loaded.push(pack_name.to_owned());
                     pack.dependencies().iter().for_each(|(_, pack_name)| self.load_parent_pack(pack_name, already_loaded, data_paths, secondary_paths, content_paths, game_info));
                     self.parent_files.extend(pack.files().clone());
@@ -1024,7 +1024,7 @@ impl Dependencies {
             // Then check in /secondary. If we have packs there, do not bother checking for content Packs.
             if let Some(ref paths) = secondary_paths {
                 if let Some(path) = paths.iter().find(|x| x.file_name().unwrap().to_string_lossy() == pack_name) {
-                    if let Ok(pack) = Pack::read_and_merge(&[path.to_path_buf()], game_info, true, false, false) {
+                    if let Ok(pack) = Pack::read_and_merge(std::slice::from_ref(path), game_info, true, false, false) {
                         already_loaded.push(pack_name.to_owned());
                         pack.dependencies().iter().for_each(|(_, pack_name)| self.load_parent_pack(pack_name, already_loaded, data_paths, secondary_paths, content_paths, game_info));
                         self.parent_files.extend(pack.files().clone());
@@ -1037,7 +1037,7 @@ impl Dependencies {
             // If nothing else works, check in content.
             if let Some(ref paths) = content_paths {
                 if let Some(path) = paths.iter().find(|x| x.file_name().unwrap().to_string_lossy() == pack_name) {
-                    if let Ok(pack) = Pack::read_and_merge(&[path.to_path_buf()], game_info, true, false, false) {
+                    if let Ok(pack) = Pack::read_and_merge(std::slice::from_ref(path), game_info, true, false, false) {
                         already_loaded.push(pack_name.to_owned());
                         pack.dependencies().iter().for_each(|(_, pack_name)| self.load_parent_pack(pack_name, already_loaded, data_paths, secondary_paths, content_paths, game_info));
                         self.parent_files.extend(pack.files().clone());

--- a/rpfm_extensions/src/diagnostics/table.rs
+++ b/rpfm_extensions/src/diagnostics/table.rs
@@ -136,7 +136,7 @@ impl DiagnosticReport for TableDiagnosticReport {
             TableDiagnosticReportType::EmptyRow => "Empty row.".to_owned(),
             TableDiagnosticReportType::EmptyKeyField(field_name) => format!("Empty key for column \"{field_name}\"."),
             TableDiagnosticReportType::EmptyKeyFields => "Empty key fields.".to_owned(),
-            TableDiagnosticReportType::DuplicatedCombinedKeys(combined_keys) => format!("Duplicated combined keys: {}.", &combined_keys),
+            TableDiagnosticReportType::DuplicatedCombinedKeys(combined_keys) => format!("Duplicated combined keys: {}.", combined_keys),
             TableDiagnosticReportType::NoReferenceTableFound(field_name) => format!("No reference table found for column \"{field_name}\"."),
             TableDiagnosticReportType::NoReferenceTableNorColumnFoundPak(field_name) => format!("No reference column found in referenced table for column \"{field_name}\". Maybe a problem with the schema?"),
             TableDiagnosticReportType::NoReferenceTableNorColumnFoundNoPak(field_name) => format!("No reference column found in referenced table for column \"{field_name}\". Did you forget to generate the Dependencies Cache, or did you generate it before installing the Assembly kit?"),

--- a/rpfm_lib/src/files/mod.rs
+++ b/rpfm_lib/src/files/mod.rs
@@ -1116,7 +1116,7 @@ pub trait Container {
                 tsv_imported = true;
                 let rfile = RFile::tsv_import_from_path(source_path, schema);
                 if let Err(error) = rfile {
-                    warn!("File with path {} failed to import as TSV. Importing it as binary. If you're using the CLI - did you forget to provide schema with --tsv-as-binary flag? Error was: {}", &source_path.to_string_lossy(), error);
+                    warn!("File with path {} failed to import as TSV. Importing it as binary. If you're using the CLI - did you forget to provide schema with --tsv-as-binary flag? Error was: {}", source_path.to_string_lossy(), error);
 
                     tsv_imported = false;
                     RFile::new_from_file_path(source_path)
@@ -1229,7 +1229,7 @@ pub trait Container {
                     tsv_imported = true;
                     let rfile = RFile::tsv_import_from_path(&file_path, schema);
                     if let Err(error) = rfile {
-                        warn!("File with path {} failed to import as TSV. Importing it as binary. If you're using the CLI - did you forget to provide schema with --tsv-as-binary flag? Error was: {}", &file_path.to_string_lossy(), error);
+                        warn!("File with path {} failed to import as TSV. Importing it as binary. If you're using the CLI - did you forget to provide schema with --tsv-as-binary flag? Error was: {}", file_path.to_string_lossy(), error);
 
                         tsv_imported = false;
                         RFile::new_from_file_path(&file_path)

--- a/rpfm_server/src/background_thread.rs
+++ b/rpfm_server/src/background_thread.rs
@@ -1210,8 +1210,8 @@ pub async fn background_loop(mut receiver: UnboundedReceiver<(UnboundedSender<Re
 
             // In case we want to decode a RigidModel PackedFile...
             Command::DecodePackedFile(pack_key, path, data_source) => {
-                info!("Trying to decode a file. Path: {}", &path);
-                info!("Trying to decode a file. Data Source: {}", &data_source);
+                info!("Trying to decode a file. Path: {}", path);
+                info!("Trying to decode a file. Data Source: {}", data_source);
 
                 match data_source {
                     DataSource::PackFile => {
@@ -2481,7 +2481,7 @@ pub async fn background_loop(mut receiver: UnboundedReceiver<(UnboundedSender<Re
                         }
 
                         if let Some((column_index, row_index)) = data.table().rows_containing_data(&ref_column, &ref_data[0]) {
-                            let path = format!("{}/ak_data", &table_folder);
+                            let path = format!("{}/ak_data", table_folder);
                             CentralCommand::send_back(&sender, Response::DataSourceStringUsizeUsize(DataSource::AssKitFiles, path, column_index, row_index[0]));
                             found = true;
                         }

--- a/rpfm_telemetry/src/logger.rs
+++ b/rpfm_telemetry/src/logger.rs
@@ -363,7 +363,7 @@ impl Logger {
 
         let mut explanation = String::new();
         if let Some(payload) = panic_info.payload().downcast_ref::<&str>() {
-            explanation.push_str(&format!("Cause: {}\n", &payload));
+            explanation.push_str(&format!("Cause: {}\n", payload));
         } else if let Some(payload) = panic_info.payload().downcast_ref::<String>() {
             explanation.push_str(&format!("Cause: {}\n", payload));
         }


### PR DESCRIPTION
Just the small ones cargo clippy -D warnings was complaining about:
useless_borrows_in_formatting in five spots across logger.rs,
files/mod.rs, background_thread.rs and dependencies/mod.rs, plus one
cloned_ref_to_slice_refs in diagnostics::table. Leaves the libs and
rpfm_server clean under -D warnings again.