### PR TITLE
Bump the crate version strings in the READMEs.

### DIFF
--- a/rpfm_extensions/README.md
+++ b/rpfm_extensions/README.md
@@ -59,7 +59,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rpfm_extensions = "4.7"
+rpfm_extensions = "5"
 ```
 
 ### Running diagnostics

--- a/rpfm_lib/README.md
+++ b/rpfm_lib/README.md
@@ -74,7 +74,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rpfm_lib = "4.7"
+rpfm_lib = "5"
 ```
 
 ### Reading a Pack


### PR DESCRIPTION
Both still show rpfm_lib = "4.7" / rpfm_extensions = "4.7" in the "Add
to Cargo.toml" snippet even though we are on 5 now. Just a docs fix, no
code touched.