### PR TITLE
Run clippy in CI so warnings do not sneak back in.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,3 +42,9 @@ jobs:
         with:
           command: test
           args: -p rpfm_lib -p rpfm_extensions -p rpfm_ipc -p rpfm_telemetry -p rpfm_server
+
+      - name: Run clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -p rpfm_lib -p rpfm_extensions -p rpfm_ipc -p rpfm_telemetry -p rpfm_server --no-deps -- -D warnings


### PR DESCRIPTION
Adds a "Run clippy" step to .github/workflows/test.yml right after the
existing build/test steps, scoped to the same crate set they already
cover (rpfm_lib, rpfm_extensions, rpfm_ipc, rpfm_telemetry, rpfm_server)
and with -D warnings so it actually fails the build.

Still using actions-rs/cargo@v1 to match the rest of the file. Migrating
off the deprecated actions-rs/* actions can be its own PR.

Heads up: this depends on the "Clippy fixes" PR landing first, otherwise
the new step will fail on the existing warnings.