### PR TITLE
Make CEO tooling ceo_db-aware and keep Assembly Kit columns on import

### DIFF
--- a/locale/English_en.ftl
+++ b/locale/English_en.ftl
@@ -1663,6 +1663,7 @@ build_ceo_instructions = <p>Instructions:</p>
         <li>Tested only under Windows.</li>
         <li>Have your Assembly Kit path configured correctly in Settings.</li>
         <li>Import all of the necessary CEO files from the Assembly Kit dependencies within RPFM.</li>
+        <li>CEO tables must be under the <b>ceo_db/</b> folder of the pack. Tables under <b>db/</b> are ignored by the build.</li>
         <li>Make any changes, then hit the <b>Build CEO</b> button. This will open BOB — BOB will close if the build is successful, and stay open if there is an error in your CEOs.</li>
         <li>Once that is done, hit <b>Import CCD</b> and it will import <b>ceo_data.ccd</b> into the <b>campaigns/</b> folder.</li>
     </ul>

--- a/rpfm_extensions/src/dependencies/mod.rs
+++ b/rpfm_extensions/src/dependencies/mod.rs
@@ -3604,26 +3604,18 @@ impl Dependencies {
 
     /// This function imports a specific table from the data it has in the AK.
     ///
-    /// Tables generated with this are VALID.
+    /// The schema version that keeps the most AK columns is used, so tables generated with this are VALID.
     pub fn import_from_ak(&self, table_name: &str, schema: &Schema) -> Result<DB> {
-        let definition = if let Some(definitions) = schema.definitions_by_table_name_cloned(table_name) {
-            if !definitions.is_empty() {
-                definitions[0].clone()
-            } else {
-                return Err(RLibError::DecodingDBNoDefinitionsFound)
-            }
-        } else {
-            return Err(RLibError::DecodingDBNoDefinitionsFound)
-        };
+        let ak_file = self.asskit_only_db_tables().get(table_name).ok_or_else(|| RLibError::AssemblyKitTableNotFound(table_name.to_owned()))?;
+
+        let ak_fields = ak_file.definition().fields_processed();
+        let ak_field_names = ak_fields.iter().map(|field| field.name()).collect::<Vec<_>>();
+        let definition = schema.definition_by_name_and_fields(table_name, &ak_field_names).ok_or(RLibError::DecodingDBNoDefinitionsFound)?;
 
         // Create the new table according to the schema, and import its data from the AK.
-        if let Some(ak_file) = self.asskit_only_db_tables().get(table_name) {
-            let mut real_table = ak_file.clone();
-            real_table.set_definition(&definition);
-            Ok(real_table)
-        } else {
-            Err(RLibError::AssemblyKitTableNotFound(table_name.to_owned()))
-        }
+        let mut real_table = ak_file.clone();
+        real_table.set_definition(definition);
+        Ok(real_table)
     }
 
     //-----------------------------------//

--- a/rpfm_extensions/src/dependencies/mod.rs
+++ b/rpfm_extensions/src/dependencies/mod.rs
@@ -1758,7 +1758,7 @@ impl Dependencies {
 
         let files = match packs {
             Some(packs) => {
-                let mut files: Vec<&RFile> = packs.values().flat_map(|pack| pack.files_by_path(&ContainerPath::Folder(format!("db/{ref_table_full}")), true)).collect();
+                let mut files: Vec<&RFile> = packs.values().flat_map(|pack| pack.files_by_paths(&ContainerPath::db_table_folders(&ref_table_full), true)).collect();
                 files.append(&mut self.db_data(&ref_table_full, true, true).unwrap_or_else(|_| vec![]));
                 files
             },
@@ -1794,7 +1794,7 @@ impl Dependencies {
 
                                     if let Some(packs) = packs {
                                         for pack in packs.values() {
-                                            files.append(&mut pack.files_by_path(&ContainerPath::Folder(format!("db/{lookup_ref_table_long}")), true));
+                                            files.append(&mut pack.files_by_paths(&ContainerPath::db_table_folders(&lookup_ref_table_long), true));
                                         }
                                     }
 
@@ -2202,7 +2202,7 @@ impl Dependencies {
 
         if let Some(packs) = packs {
             for pack in packs.values() {
-                let files = pack.files_by_path(&ContainerPath::Folder(format!("db/{table_name}")), true);
+                let files = pack.files_by_paths(&ContainerPath::db_table_folders(table_name), true);
                 values.extend(files.par_iter().filter_map(|file| {
                     if let Ok(RFileDecoded::DB(table)) = file.decoded() {
                         table.definition().column_position_by_name(column_name).map(|column| table.data().par_iter().map(|row| row[column].data_to_string().to_string()).collect::<Vec<_>>())
@@ -2230,7 +2230,7 @@ impl Dependencies {
 
         if let Some(packs) = packs {
             for pack in packs.values() {
-                let files = pack.files_by_path(&ContainerPath::Folder(format!("db/{table_name}")), true);
+                let files = pack.files_by_paths(&ContainerPath::db_table_folders(table_name), true);
                 values.extend(files.par_iter().filter_map(|file| {
                     if let Ok(RFileDecoded::DB(table)) = file.decoded() {
                         if let Some(column) = table.definition().column_position_by_name(key_column_name) {

--- a/rpfm_lib/src/files/db/mod.rs
+++ b/rpfm_lib/src/files/db/mod.rs
@@ -600,8 +600,7 @@ impl DB {
         let mut table_name = table_name.to_owned();
         while let Some((ref_table, ref_column)) = field.is_reference(patches.as_ref()) {
             let ref_table_name = format!("{ref_table}_tables");
-            let table_folder = format!("db/{ref_table_name}");
-            let parent_files = pack.files_by_type_and_paths_mut(&[FileType::DB], &[ContainerPath::Folder(table_folder.to_owned())], true);
+            let parent_files = pack.files_by_type_and_paths_mut(&[FileType::DB], &ContainerPath::db_table_folders(&ref_table_name), true);
             if !parent_files.is_empty() {
                 if let Ok(RFileDecoded::DB(table)) = parent_files[0].decoded() {
                     if let Some(index) = table.definition().column_position_by_name(&ref_column) {
@@ -624,7 +623,7 @@ impl DB {
         // Add the source table and column to the list to edit.
         ref_table_data.insert(table_name, vec![field.name().to_owned()]);
 
-        let container_paths = ref_table_data.keys().map(|ref_table_name| ContainerPath::Folder("db/".to_owned() + ref_table_name)).collect::<Vec<_>>();
+        let container_paths = ref_table_data.keys().flat_map(|ref_table_name| ContainerPath::db_table_folders(ref_table_name)).collect::<Vec<_>>();
         let mut files = pack.files_by_paths_mut(&container_paths, true);
         let mut loc_keys: Vec<(String, String)> = vec![];
 

--- a/rpfm_lib/src/files/mod.rs
+++ b/rpfm_lib/src/files/mod.rs
@@ -2963,6 +2963,16 @@ impl ContainerPath {
         }
     }
 
+    /// This function returns the `db/` and `ceo_db/` folder paths for the provided *table_name*.
+    ///
+    /// Use it with `files_by_paths` instead of hardcoding the `db/` prefix.
+    pub fn db_table_folders(table_name: &str) -> Vec<ContainerPath> {
+        vec![
+            ContainerPath::Folder(format!("db/{table_name}")),
+            ContainerPath::Folder(format!("ceo_db/{table_name}")),
+        ]
+    }
+
     /// This function returns the path of the parent folder of the provided [ContainerPath].
     ///
     /// If the provided [ContainerPath] corresponds to a Container root, the path returned will be the current one.

--- a/rpfm_lib/src/files/pack/pack_test.rs
+++ b/rpfm_lib/src/files/pack/pack_test.rs
@@ -347,3 +347,17 @@ fn test_save_repoints_lazy_files() {
 
     let _ = remove_file(path_2);
 }
+
+#[test]
+fn test_db_table_folders_matches_db_and_ceo_db() {
+    let mut pack = Pack::default();
+    pack.insert(RFile::new_from_vec(&[], FileType::DB, 0, "db/foo_tables/data__")).unwrap();
+    pack.insert(RFile::new_from_vec(&[], FileType::DB, 0, "ceo_db/foo_tables/data__")).unwrap();
+    pack.insert(RFile::new_from_vec(&[], FileType::DB, 0, "db/bar_tables/data__")).unwrap();
+
+    let files = pack.files_by_paths(&ContainerPath::db_table_folders("foo_tables"), true);
+    let mut paths = files.iter().map(|file| file.path_in_container_raw().to_owned()).collect::<Vec<_>>();
+    paths.sort();
+
+    assert_eq!(paths, vec!["ceo_db/foo_tables/data__".to_owned(), "db/foo_tables/data__".to_owned()]);
+}

--- a/rpfm_lib/src/schema/mod.rs
+++ b/rpfm_lib/src/schema/mod.rs
@@ -803,6 +803,23 @@ impl Schema {
         self.definitions.get(table_name)?.iter().find(|definition| *definition.version() == table_version)
     }
 
+    /// Returns the definition of a table that keeps the most of the provided field names.
+    ///
+    /// Ties go to the first (newest) definition.
+    pub fn definition_by_name_and_fields(&self, table_name: &str, field_names: &[&str]) -> Option<&Definition> {
+        self.definitions.get(table_name)?.iter()
+            .map(|definition| {
+                let fields = definition.fields_processed();
+                let kept = field_names.iter().filter(|name| fields.iter().any(|field| field.name() == **name)).count();
+                (definition, kept)
+            })
+            .fold(None, |best: Option<(&Definition, usize)>, candidate| match best {
+                Some((_, best_kept)) if best_kept >= candidate.1 => best,
+                _ => Some(candidate),
+            })
+            .map(|(definition, _)| definition)
+    }
+
     /// Returns a mutable reference to a specific table definition by name and version.
     ///
     /// # Arguments
@@ -2321,4 +2338,29 @@ fn ordered_map_definitions<S>(value: &HashMap<String, Vec<Definition>>, serializ
 fn ordered_map_patches<S>(value: &HashMap<String, HashMap<String, HashMap<String, String>>>, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer, {
     let ordered: BTreeMap<_, BTreeMap<_, BTreeMap<_, _>>> = value.iter().map(|(a, x)| (a, x.iter().map(|(b, y)| (b, y.iter().collect())).collect())).collect();
     ordered.serialize(serializer)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn field(name: &str) -> Field {
+        Field { name: name.to_owned(), field_type: FieldType::StringU8, is_key: true, ..Default::default() }
+    }
+
+    #[test]
+    fn test_definition_by_name_and_fields_prefers_version_keeping_most_columns() {
+        let table = "ceo_initial_datas_tables";
+        let mut schema = Schema::default();
+        schema.add_definition(table, &Definition::new_with_fields(1, &[field("key")], &[], None));
+        schema.add_definition(table, &Definition::new_with_fields(0, &[field("key"), field("template_manager")], &[], None));
+
+        let two_columns = schema.definition_by_name_and_fields(table, &["key", "template_manager"]).unwrap();
+        assert_eq!(*two_columns.version(), 0);
+
+        let one_column = schema.definition_by_name_and_fields(table, &["key"]).unwrap();
+        assert_eq!(*one_column.version(), 1);
+
+        assert!(schema.definition_by_name_and_fields("missing_tables", &["key"]).is_none());
+    }
 }

--- a/rpfm_server/src/background_thread.rs
+++ b/rpfm_server/src/background_thread.rs
@@ -2383,7 +2383,7 @@ pub async fn background_loop(mut receiver: UnboundedReceiver<(UnboundedSender<Re
 
             Command::GoToDefinition(pack_key, ref_table, mut ref_column, ref_data) => {
                 let table_name = format!("{ref_table}_tables");
-                let table_folder = format!("db/{table_name}");
+                let table_folders = ContainerPath::db_table_folders(&table_name);
                 let mut found = false;
 
                 // Search first in the pack that sent the request (if still open), then in the rest of the open packs.
@@ -2394,7 +2394,7 @@ pub async fn background_loop(mut receiver: UnboundedReceiver<(UnboundedSender<Re
                 packs_to_search.extend(packs.iter().filter(|kv| kv.0 != &pack_key).map(|kv| kv.1));
 
                 for pack in packs_to_search {
-                    let packed_files = pack.files_by_path(&ContainerPath::Folder(table_folder.to_owned()), true);
+                    let packed_files = pack.files_by_paths(&table_folders, true);
                     for packed_file in &packed_files {
                         if let Ok(RFileDecoded::DB(data)) = packed_file.decoded() {
 
@@ -2481,7 +2481,7 @@ pub async fn background_loop(mut receiver: UnboundedReceiver<(UnboundedSender<Re
                         }
 
                         if let Some((column_index, row_index)) = data.table().rows_containing_data(&ref_column, &ref_data[0]) {
-                            let path = format!("{}/ak_data", &table_folder);
+                            let path = format!("db/{table_name}/ak_data");
                             CentralCommand::send_back(&sender, Response::DataSourceStringUsizeUsize(DataSource::AssKitFiles, path, column_index, row_index[0]));
                             found = true;
                         }
@@ -2494,7 +2494,7 @@ pub async fn background_loop(mut receiver: UnboundedReceiver<(UnboundedSender<Re
             },
 
             Command::SearchReferences(pack_key, reference_map, value) => {
-                let paths = reference_map.keys().map(|x| ContainerPath::Folder(format!("db/{x}"))).collect::<Vec<ContainerPath>>();
+                let paths = reference_map.keys().flat_map(|x| ContainerPath::db_table_folders(x)).collect::<Vec<ContainerPath>>();
                 let Some(pack) = get_pack(&packs, &pack_key, &sender) else { continue 'background_loop; };
                 let files = pack.files_by_paths(&paths, true);
 
@@ -3492,7 +3492,7 @@ pub async fn background_loop(mut receiver: UnboundedReceiver<(UnboundedSender<Re
                     .filter(|p| {
                         let mut parts = p.splitn(3, '/');
                         let prefix = parts.next().unwrap_or("");
-                        if prefix != "db" && prefix != "ceo_db" {
+                        if prefix != "ceo_db" {
                             return false;
                         }
                         parts.next()
@@ -3506,8 +3506,8 @@ pub async fn background_loop(mut receiver: UnboundedReceiver<(UnboundedSender<Re
                 if ceo_table_paths.is_empty() {
                     for (orig, bak) in &xml_backups { let _ = std::fs::rename(bak, orig); }
                     CentralCommand::send_back(&sender, Response::Error(
-                        "No CEO tables found in the pack (looked in db/ and ceo_db/ folders). \
-                         Import CEO tables from the Assembly Kit.".into()
+                        "No CEO tables found in the pack (only the ceo_db/ folder is scanned). \
+                         Import CEO tables from the Assembly Kit, or move any CEO tables under db/ to ceo_db/.".into()
                     ));
                     continue 'background_loop;
                 }
@@ -3547,7 +3547,7 @@ pub async fn background_loop(mut receiver: UnboundedReceiver<(UnboundedSender<Re
                 // db tables (e.g. data__, data__01) are combined into one XML.
                 let mut xml_groups: std::collections::BTreeMap<String, Vec<String>> = std::collections::BTreeMap::new();
                 for table_path in &ceo_table_paths {
-                    // "db/ceos_tables/data__" -> folder="ceos_tables" -> xml="ceos.xml"
+                    // "ceo_db/ceos_tables/data__" -> folder="ceos_tables" -> xml="ceos.xml"
                     let parts: Vec<&str> = table_path.split('/').collect();
                     if parts.len() < 2 { continue; }
                     let folder = parts[1];


### PR DESCRIPTION
## Summary

Three fixes for Three Kingdoms CEO tables, which live under `ceo_db/` instead of `db/`.

### Build CEO scans only `ceo_db/`
- Build CEO now exports only tables under `ceo_db/`. CEO tables under `db/` are ignored, and the error message and instructions say so.
- Previously a table present under both folders had its rows concatenated into one XML for BOB.

### Pack reference lookups search both `db/` and `ceo_db/`
- Add `ContainerPath::db_table_folders`, returning the `db/` and `ceo_db/` folders for a table name.
- Reference data, lookup text, column-value helpers, Go To Definition, Search References and cascade edition now search both folders in open packs. Previously keys defined in a pack's own `ceo_db/` tables were never found, so `ceo_db/ceo_initial_data_to_stages_tables` showed InvalidReference errors for `ceo_initial_datas` keys.
- Unit test for `db_table_folders`.

### Assembly Kit import keeps the columns the schema knows about
- `import_from_ak` always applied the newest schema definition, then dropped any AK column missing from it. For `ceo_initial_datas_tables` that meant version 1 (`key` only) was applied and `template_manager` was silently lost before the table was written to `ceo_db/`.
- Add `Schema::definition_by_name_and_fields`, which returns the definition keeping the most of the given field names (ties go to the newest), and use it in `import_from_ak`. Tables where every version keeps the same columns still get the newest version, so existing imports are unchanged.
- Game-file imports are untouched: they keep the vanilla file's path and version.
- Unit test for `definition_by_name_and_fields`.

## Verification
- `cargo test -p rpfm_lib` for the two new tests.
- Release build of `rpfm_ui` and `rpfm_server`, manually tested in 3K: `ceo_db/ceo_initial_data_to_stages_tables` no longer flags pack-local `ceo_initial_datas` keys; AK import of `ceo_initial_datas` lands in `ceo_db/` with both columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSgGU6WdQygtQpR6Qt1vtA
